### PR TITLE
ets_cache: Cache {ok, Val} rather than Val

### DIFF
--- a/src/ets_cache.erl
+++ b/src/ets_cache.erl
@@ -187,7 +187,7 @@ update(Name, Key, Val, UpdateFun, Nodes) ->
 		 end,
     if NeedUpdate ->
 	    NewVal = case UpdateFun() of
-			 ok -> Val;
+			 ok -> {ok, Val};
 			 {ok, Val1} -> {ok, Val1};
 			 error -> error;
 			 Other -> {error, Other}


### PR DESCRIPTION
If the `update_fun()` returns `ok`, cache `{ok, Val}` rather than `Val`.  Otherwise the `ets_cache:update()` caller would always have to specify `{ok, Val}`.