### PR TITLE
Don't try to compile ets_cache.erl to native code

### DIFF
--- a/src/ets_cache.erl
+++ b/src/ets_cache.erl
@@ -34,6 +34,7 @@
 	 new_counter_nif/0, get_counter_nif/1, incr_counter_nif/1,
 	 delete_counter_nif/1]).
 
+-compile(no_native).
 -on_load(load_nif/0).
 
 -include_lib("stdlib/include/ms_transform.hrl").


### PR DESCRIPTION
Modules that use `-on_load()` directives cannot be compiled to native code.